### PR TITLE
Don't prune data structure in TOML Fortran

### DIFF
--- a/app/tomlf_test_module.f90
+++ b/app/tomlf_test_module.f90
@@ -23,8 +23,7 @@ module tomlf_test_module
    use tomlf_diagnostic, only : toml_level
    use tomlf_build, only : get_value
    use tomlf_error, only : toml_error
-   use tomlf_type, only : toml_table, toml_value, cast_to_table, &
-      & toml_visitor, toml_array, toml_keyval, toml_key, len
+   use tomlf_type, only : toml_table, toml_value, cast_to_table
 
    use iso_fortran_env, only: int64
 
@@ -45,13 +44,6 @@ module tomlf_test_module
    interface json_loads
       module procedure :: json_load_string
    end interface json_loads
-
-   !> Implement pruning of annotated values as visitor
-   type, extends(toml_visitor) :: json_prune
-   contains
-      !> Traverse the AST and prune all annotated values
-      procedure :: visit
-   end type json_prune
 
 contains
 
@@ -132,148 +124,12 @@ subroutine prune(table)
    type(toml_table), allocatable :: root
    type(toml_table), pointer :: ptr
    class(toml_value), pointer :: child
-   type(json_prune) :: pruner
 
    call move_alloc(table, root)
    call root%get("_", child)
 
    ptr => cast_to_table(child)
    if (associated(ptr)) table = ptr
-
-   if (allocated(table)) call table%accept(pruner)
 end subroutine prune
-
-!> Visit a TOML value
-subroutine visit(self, val)
-   !> Instance of the JSON pruner
-   class(json_prune), intent(inout) :: self
-   !> TOML value to visit
-   class(toml_value), intent(inout) :: val
-
-   select type(val)
-   class is(toml_array)
-      call visit_array(self, val)
-   class is(toml_table)
-      call visit_table(self, val)
-   end select
-end subroutine visit
-
-!> Visit a TOML array
-subroutine visit_array(visitor, array)
-   !> Instance of the JSON pruner
-   class(json_prune), intent(inout) :: visitor
-   !> TOML value to visit
-   type(toml_array), intent(inout) :: array
-
-   class(toml_value), allocatable :: val, tmp
-   character(kind=tfc, len=:), allocatable :: str
-   type(toml_key), allocatable :: vt(:)
-   integer :: i, n, stat
-
-   n = len(array)
-   do i = 1, n
-      call array%shift(val)
-      select type(val)
-      class default
-         call val%accept(visitor)
-      class is(toml_table)
-         call val%get_keys(vt)
-         if (val%has_key("type") .and. val%has_key("value") .and. size(vt)==2) then
-            call get_value(val, "type", str)
-            call prune_value(tmp, val, str)
-            call val%destroy
-            call tmp%accept(visitor)
-            call array%push_back(tmp, stat)
-            cycle
-         else
-            call val%accept(visitor)
-         end if
-      end select
-      call array%push_back(val, stat)
-   end do
-end subroutine visit_array
-
-!> Visit a TOML table
-subroutine visit_table(visitor, table)
-   !> Instance of the JSON pruner
-   class(json_prune), intent(inout) :: visitor
-   !> TOML table to visit
-   type(toml_table), intent(inout) :: table
-
-   class(toml_value), pointer :: ptr
-   class(toml_value), allocatable :: val
-   character(kind=tfc, len=:), allocatable :: str
-   type(toml_key), allocatable :: list(:), vt(:)
-   integer :: i, n, stat
-
-   call table%get_keys(list)
-   n = size(list, 1)
-
-   do i = 1, n
-      call table%get(list(i)%key, ptr)
-      select type(ptr)
-      class default
-         call ptr%accept(visitor)
-      class is(toml_table)
-         call ptr%get_keys(vt)
-         if (ptr%has_key("type") .and. ptr%has_key("value") .and. size(vt)==2) then
-            call get_value(ptr, "type", str)
-            call prune_value(val, ptr, str)
-            call val%accept(visitor)
-            call table%delete(list(i)%key)
-            call table%push_back(val, stat)
-         else
-            call ptr%accept(visitor)
-         end if
-      end select
-   end do
-end subroutine visit_table
-
-subroutine prune_value(val, table, str)
-   !> Actual TOML value
-   class(toml_value), allocatable, intent(out) :: val
-   !> TOML table to prune
-   type(toml_table), intent(inout) :: table
-   !> Value kind
-   character(kind=tfc, len=*), intent(in) :: str
-
-   class(toml_value), pointer :: ptr
-   character(:, tfc), pointer :: sval
-   character(kind=tfc, len=:), allocatable :: tmp
-   integer :: stat
-   type(toml_datetime) :: dval
-   integer(tfi) :: ival
-   real(tfr) :: fval
-
-   call table%get("value", ptr)
-   allocate(val, source=ptr)
-   if (allocated(table%key)) then
-      val%key = table%key
-   else
-      deallocate(val%key)
-   end if
-
-   select type(val)
-   class is(toml_keyval)
-      call val%get(sval)
-      select case(str)
-      case("date", "time", "datetime", "date-local", "time-local", "datetime-local")
-         dval = toml_datetime(sval)
-         call val%set(dval)
-      case("bool")
-         call val%set(sval == "true")
-      case("integer")
-         read(sval, *, iostat=stat) ival
-         if (stat == 0) then
-            call val%set(ival)
-         end if
-      case("float")
-         read(sval, *, iostat=stat) fval
-         if (stat == 0) then
-            call val%set(fval)
-         end if
-      end select
-   end select
-end subroutine prune_value
 
 end module tomlf_test_module


### PR DESCRIPTION
Remove the transformation step of the data structure accounting for the JSON encoding required by https://github.com/burntsushi/toml-test.

```diff
@@ GFortran 12.1.0 @@
      read file to a string :   0.0011  seconds
               json_fortran :   0.2121  seconds
                       fson :   1.5707  seconds
                      rojff :   0.2728  seconds
+                     tomlf :   0.2701  seconds
-                     tomlf :   0.9024  seconds
```

```diff
@@ Intel Fortran Classic 2021.6.0 @@
      read file to a string :   0.0012  seconds
               json_fortran :   0.6471  seconds
                       fson :   1.1885  seconds
                      rojff :   0.6011  seconds
+                     tomlf :   0.5950  seconds
-                     tomlf :   9.3425  seconds
```

Done on my somewhat old laptop CPU

```
❯ lscpu
Architecture:            x86_64
  CPU op-mode(s):        32-bit, 64-bit
  Address sizes:         39 bits physical, 48 bits virtual
  Byte Order:            Little Endian
CPU(s):                  4
  On-line CPU(s) list:   0-3
Vendor ID:               GenuineIntel
  Model name:            Intel(R) Core(TM) i7-6500U CPU @ 2.50GHz
    CPU family:          6
    Model:               78
    Thread(s) per core:  2
    Core(s) per socket:  2
    Socket(s):           1
    Stepping:            3
    CPU(s) scaling MHz:  52%
    CPU max MHz:         3100.0000
    CPU min MHz:         400.0000
    BogoMIPS:            5202.65
```